### PR TITLE
Remove scheme on generateYoutubeLiveChatUrl filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.3 - 2024-07-13
+### Fixed 
+- Remove scheme on generateYoutubeLiveChatUrl filter.
+- 
 ## 3.0.1 - 2024-06-19
 ### Added
 - Add generateYoutubeLiveChatUrl filter.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "aodihis/video-utils",
     "description": "Twig filter to get the video id of youtube or Vimeo URL.",
     "type": "craft-plugin",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "keywords": [
         "craft",
         "cms",

--- a/src/twigextensions/VideoUtilsTwigExtension.php
+++ b/src/twigextensions/VideoUtilsTwigExtension.php
@@ -137,6 +137,8 @@ class VideoUtilsTwigExtension extends AbstractExtension
             return '';
         }
         $domain = Craft::$app->urlManager->hostInfo;
+        $domain = preg_replace("(^https?://)", "", $domain );
+        $domain = rtrim($domain,"/");
         $ytId = $this->getYoutubeId($url);
         return "https://www.youtube.com/live_chat?v=$ytId&embed_domain=$domain";
 


### PR DESCRIPTION
Remove the scheme on the generateYoutubeLiveChatUrl filter, so it will return the domain name only.
Issue #9 